### PR TITLE
Add parameter name to instantiate controller from storyboard

### DIFF
--- a/Blackboard/Info.plist
+++ b/Blackboard/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.1</string>
+	<string>0.9.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Blackboard/Source/BlackboardViewController.swift
+++ b/Blackboard/Source/BlackboardViewController.swift
@@ -29,6 +29,7 @@ struct BlackboardViewController {
     let className: String
     let identifier: String?
     let navigationControllerIdentifier: String?
+    let parameterName: String
     
     let segues: [BlackboardSegue]
     let tableViewCells: [BlackboardTableViewCell]
@@ -46,6 +47,8 @@ extension BlackboardViewController {
         className = customClass
         identifier = viewController.storyboardIdentifier
         navigationControllerIdentifier = storyboard.navigationControllerFor(id: viewController.id)?.storyboardIdentifier
+        
+        parameterName = customClass.lowercaseFirstCharacterString
         
         segues = viewController.segues
             .flatMap { BlackboardSegue(segue: $0, storyboard: storyboard) }
@@ -81,9 +84,9 @@ extension SwiftSource {
     func appendInstantiateViewController(viewController: BlackboardViewController) {
         guard let identifier = viewController.identifier else { return }
         
-        append("final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((\(viewController.className)) -> Void) = {_ in}) -> \(viewController.className)") {
+        append("final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((\(viewController.parameterName): \(viewController.className)) -> Void) = {_ in}) -> \(viewController.className)") {
             append("let viewController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier(\"\(identifier)\") as! \(viewController.className)")
-            append("initialize(viewController)")
+            append("initialize(\(viewController.parameterName): viewController)")
             append("return viewController")
         }
         append()
@@ -92,10 +95,10 @@ extension SwiftSource {
     func appendInstantiateNavigationController(viewController: BlackboardViewController) {
         guard let navigationControllerIdentifier = viewController.navigationControllerIdentifier else { return }
         
-        append("final class func instantiateNavigationControllerFromStoryboard(@noescape initialize: ((\(viewController.className)) -> Void) = {_ in}) -> UINavigationController") {
+        append("final class func instantiateNavigationControllerFromStoryboard(@noescape initialize: ((\(viewController.parameterName): \(viewController.className)) -> Void) = {_ in}) -> UINavigationController") {
             append("let navigationController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier(\"\(navigationControllerIdentifier)\") as! UINavigationController")
             append("let viewController = navigationController.viewControllers.first as! \(viewController.className)")
-            append("initialize(viewController)")
+            append("initialize(\(viewController.parameterName): viewController)")
             append("return navigationController")
         }
         append()

--- a/BlackboardTests/Resources/GeneratedSource/NavigationStoryboardExtensions.swift
+++ b/BlackboardTests/Resources/GeneratedSource/NavigationStoryboardExtensions.swift
@@ -20,16 +20,16 @@ private class InitializeBlockObject {
 
 extension MenuViewController {
     
-    final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((MenuViewController) -> Void) = {_ in}) -> MenuViewController {
+    final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((menuViewController: MenuViewController) -> Void) = {_ in}) -> MenuViewController {
         let viewController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier("MenuViewController") as! MenuViewController
-        initialize(viewController)
+        initialize(menuViewController: viewController)
         return viewController
     }
     
-    final class func instantiateNavigationControllerFromStoryboard(@noescape initialize: ((MenuViewController) -> Void) = {_ in}) -> UINavigationController {
+    final class func instantiateNavigationControllerFromStoryboard(@noescape initialize: ((menuViewController: MenuViewController) -> Void) = {_ in}) -> UINavigationController {
         let navigationController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier("MenuNavigationController") as! UINavigationController
         let viewController = navigationController.viewControllers.first as! MenuViewController
-        initialize(viewController)
+        initialize(menuViewController: viewController)
         return navigationController
     }
     
@@ -45,16 +45,16 @@ extension MenuViewController {
 
 extension WelcomeViewController {
     
-    final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((WelcomeViewController) -> Void) = {_ in}) -> WelcomeViewController {
+    final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((welcomeViewController: WelcomeViewController) -> Void) = {_ in}) -> WelcomeViewController {
         let viewController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier("WelcomeViewController") as! WelcomeViewController
-        initialize(viewController)
+        initialize(welcomeViewController: viewController)
         return viewController
     }
     
-    final class func instantiateNavigationControllerFromStoryboard(@noescape initialize: ((WelcomeViewController) -> Void) = {_ in}) -> UINavigationController {
+    final class func instantiateNavigationControllerFromStoryboard(@noescape initialize: ((welcomeViewController: WelcomeViewController) -> Void) = {_ in}) -> UINavigationController {
         let navigationController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier("WelcomeNavigationController") as! UINavigationController
         let viewController = navigationController.viewControllers.first as! WelcomeViewController
-        initialize(viewController)
+        initialize(welcomeViewController: viewController)
         return navigationController
     }
     

--- a/BlackboardTests/Resources/GeneratedSource/TableStoryboardExtensions.swift
+++ b/BlackboardTests/Resources/GeneratedSource/TableStoryboardExtensions.swift
@@ -20,9 +20,9 @@ private class InitializeBlockObject {
 
 extension TableViewController {
     
-    final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((TableViewController) -> Void) = {_ in}) -> TableViewController {
+    final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((tableViewController: TableViewController) -> Void) = {_ in}) -> TableViewController {
         let viewController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier("TableViewController") as! TableViewController
-        initialize(viewController)
+        initialize(tableViewController: viewController)
         return viewController
     }
     
@@ -64,9 +64,9 @@ extension TableViewController {
 
 extension ViewController {
     
-    final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((ViewController) -> Void) = {_ in}) -> ViewController {
+    final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((viewController: ViewController) -> Void) = {_ in}) -> ViewController {
         let viewController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier("ViewController") as! ViewController
-        initialize(viewController)
+        initialize(viewController: viewController)
         return viewController
     }
     

--- a/bin/blackboard
+++ b/bin/blackboard
@@ -940,6 +940,7 @@ struct BlackboardViewController {
     let className: String
     let identifier: String?
     let navigationControllerIdentifier: String?
+    let parameterName: String
     
     let segues: [BlackboardSegue]
     let tableViewCells: [BlackboardTableViewCell]
@@ -957,6 +958,8 @@ extension BlackboardViewController {
         className = customClass
         identifier = viewController.storyboardIdentifier
         navigationControllerIdentifier = storyboard.navigationControllerFor(id: viewController.id)?.storyboardIdentifier
+        
+        parameterName = customClass.lowercaseFirstCharacterString
         
         segues = viewController.segues
             .flatMap { BlackboardSegue(segue: $0, storyboard: storyboard) }
@@ -992,9 +995,9 @@ extension SwiftSource {
     func appendInstantiateViewController(viewController: BlackboardViewController) {
         guard let identifier = viewController.identifier else { return }
         
-        append("final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((\(viewController.className)) -> Void) = {_ in}) -> \(viewController.className)") {
+        append("final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((\(viewController.parameterName): \(viewController.className)) -> Void) = {_ in}) -> \(viewController.className)") {
             append("let viewController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier(\"\(identifier)\") as! \(viewController.className)")
-            append("initialize(viewController)")
+            append("initialize(\(viewController.parameterName): viewController)")
             append("return viewController")
         }
         append()
@@ -1003,10 +1006,10 @@ extension SwiftSource {
     func appendInstantiateNavigationController(viewController: BlackboardViewController) {
         guard let navigationControllerIdentifier = viewController.navigationControllerIdentifier else { return }
         
-        append("final class func instantiateNavigationControllerFromStoryboard(@noescape initialize: ((\(viewController.className)) -> Void) = {_ in}) -> UINavigationController") {
+        append("final class func instantiateNavigationControllerFromStoryboard(@noescape initialize: ((\(viewController.parameterName): \(viewController.className)) -> Void) = {_ in}) -> UINavigationController") {
             append("let navigationController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier(\"\(navigationControllerIdentifier)\") as! UINavigationController")
             append("let viewController = navigationController.viewControllers.first as! \(viewController.className)")
-            append("initialize(viewController)")
+            append("initialize(\(viewController.parameterName): viewController)")
             append("return navigationController")
         }
         append()
@@ -1026,7 +1029,7 @@ class BlackboardMain {
         // Version
         
         if arguments.contains("--version") {
-            print("Blackboard Version 0.9.1")
+            print("Blackboard Version 0.9.2")
             exit(0)
         }
         

--- a/bin/make-blackboard.sh
+++ b/bin/make-blackboard.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# Copyright (c) 2016 Nathan E. Walczak
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
 
 BIN_ROOT=`dirname "$0"`
 PROJECT_ROOT=`dirname "$BIN_ROOT"`


### PR DESCRIPTION
Add named parameter to the instantiate controllers functions.

## Description
```swift
final class func instantiateViewControllerFromStoryboard(@noescape initialize: ((welcomeViewController: WelcomeViewController) -> Void) = {_ in}) -> WelcomeViewController {
    let viewController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier("WelcomeViewController") as! WelcomeViewController
    initialize(welcomeViewController: viewController)
    return viewController
}
```

```swift
final class func instantiateNavigationControllerFromStoryboard(@noescape initialize: ((welcomeViewController: WelcomeViewController) -> Void) = {_ in}) -> UINavigationController {
    let navigationController = sharedStoryboardInstance.instantiateViewControllerWithIdentifier("WelcomeNavigationController") as! UINavigationController
    let viewController = navigationController.viewControllers.first as! WelcomeViewController
    initialize(welcomeViewController: viewController)
    return navigationController
}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
