### PR TITLE
Fix make script so it can run from any directory

### DIFF
--- a/bin/make-blackboard.sh
+++ b/bin/make-blackboard.sh
@@ -24,10 +24,9 @@
 #
 
 BIN_ROOT=`dirname "$0"`
-PROJECT_ROOT=`dirname "$BIN_ROOT"`
+PROJECT_ROOT="$BIN_ROOT/.."
 
 SOURCE="$PROJECT_ROOT/Blackboard/Source"
-TARGET="$PROJECT_ROOT/build"
 
 BLACKBOARD="$BIN_ROOT/blackboard"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix make script so it can run from any directory.

## Description
This allows the make script to run from any directory.
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The make script previously would previously only run from the `bin` directory.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
